### PR TITLE
Introduce sleep after creating role & policy

### DIFF
--- a/src/clojider/aws.clj
+++ b/src/clojider/aws.clj
@@ -130,6 +130,7 @@
   (let [role (str "clojider-role-" region)
         policy (str "clojider-policy-" region)
         role-arn (create-role-and-policy role policy bucket)]
+    (Thread/sleep (* 10 1000))
     (create-results-bucket bucket region)
     (store-jar-to-bucket bucket file)
     (create-lambda-fn "clojider-load-testing-lambda" bucket region role-arn)))


### PR DESCRIPTION
Trying to work around issue
https://github.com/mhjort/clojider/issues/8
by avoiding a possible race condition between
creating a policy and using it.

The constant 10 seconds comes from this comment that it took them 7 seconds to get the change to propagate:
https://github.com/Miserlou/Zappa/issues/249#issuecomment-290290943

As a user of the install script, it doesn't seem too bad to wait as it's not done frequently. I could also see that a polling version or a retry strategy of the `create-lambda-fn` would be nicer.